### PR TITLE
Update go.mod to go 1.16 | Add examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,11 +406,14 @@ place to put all legal and authorship information in addition to just
 the version. Such is required by most all free software and open-source
 licenses.
 
+### Examples
+
+For examples, please refer to the [examples](examples) directory.
+
 ## TODO
 
 Here's some stuff we know I want to add but haven't made issues or time for yet:
 
-* move to 1.16, root out deprecated `ioutil`
 * fix broken subcommands of subcommands with tab completion and usage
 * support `<file>` syntax formatting rendered as all caps upper without
   the angle brackets and underlined, or just leave if no support in

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,4 @@
+# Example implementations of [cmdtab](https://github.com/rwxrob/cmdtab)
+
+* [basic](basic)
+* [import another cmdtab subcommand](iacts)

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,11 @@
+# Basic [cmdtab](https://github.com/rwxrob/cmdtab) Implementation
+
+This example demonstrates a basic implementation of a cmdtab-based CLI.
+
+## Getting Started
+
+`go mod tidy`
+
+`go install`
+
+`basic help`

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -1,0 +1,19 @@
+package main
+
+import "github.com/rwxrob/cmdtab"
+
+func init() {
+	x := cmdtab.New("basic", "hello")
+	x.Version = `v1.0.0` // Use semantic versioning
+	x.Usage = `[hello <word>]`
+	x.Summary = `this is a short description of the command`
+	x.Description = `This is a more detailed summary of the command. In
+	this context, the *minimal* command is an example of the minimal
+	implementation of the cmdtab library. It has one subcommand (hello)
+	which can be used with or without a <word>. If a word is provided
+	it will output 'Hello <word>!'. If a word is not provided it will
+	output 'Hello world!'.`
+	x.License = `MPL-v2.0`
+	// For all of the available variables please reference the `command.go`
+	// file found at	https://github.com/rwxrob/cmdtab/blob/main/command.go#L9
+}

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -1,0 +1,5 @@
+module github.com/rwxrob/cmdtab/examples/basic
+
+go 1.16
+
+require github.com/rwxrob/cmdtab v0.5.0

--- a/examples/basic/go.sum
+++ b/examples/basic/go.sum
@@ -1,0 +1,2 @@
+github.com/rwxrob/cmdtab v0.5.0 h1:WrzKLQDyoXk+jIHUjIY2u59tBzcbYXAbqOeynXLnGiA=
+github.com/rwxrob/cmdtab v0.5.0/go.mod h1:TWGCTFAm9NlO9mR6aUB5dltAhcVK1FTiCzF7WLXwGgQ=

--- a/examples/basic/hello.go
+++ b/examples/basic/hello.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/rwxrob/cmdtab"
+)
+
+func init() {
+	x := cmdtab.New("hello")
+	x.Version = `v1.0.0` // Use semantic versioning
+	x.Usage = `[<word>]`
+	x.Summary = `this is a brief description of the command`
+	x.Description = `This is a more detailed summary of the command. In
+	this context, the *hello* command outputs 'Hello [args]!'`
+	x.Method = func(args []string) error {
+		if len(args) == 0 {
+			fmt.Println("Hello world!")
+		} else {
+			fmt.Printf("Hello %s!\n", args)
+		}
+		return nil
+	}
+}

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/rwxrob/cmdtab"
+
+func main() { cmdtab.Execute("basic") }

--- a/examples/iacts/README.md
+++ b/examples/iacts/README.md
@@ -1,0 +1,35 @@
+# Import Another [cmdtab](https://github.com/rwxrob/cmdtab) Subcommand (iacts)
+
+This example demonstrates the power of utilizing the existing underlying
+infrastructure that Go and modules provide.
+
+1. Include the 3rd party module in the imports as an anonymous import
+```Go
+import (
+	"github.com/rwxrob/cmdtab"
+	_ "github.com/rwxrob/cmdtab-pomo
+)
+```
+
+2. Add the subcommand to the root command
+```Go
+x := cmdtab.New("<root>", "pomo")
+```
+
+3. `go mod tidy`
+
+4. `go install`
+
+5. `complete -C <root> <root>`
+
+There is the potential to embed a hidden command that is built into
+the library itself, allowing for *any* cmdtab-based CLI to be able
+to import and manage 3rd party cmdtab-based subcommands.
+
+## Getting Started
+
+`go mod tidy`
+
+`go install
+
+`iacts help links`

--- a/examples/iacts/go.mod
+++ b/examples/iacts/go.mod
@@ -1,0 +1,8 @@
+module github.com/rwxrob/cmdtab/examples/iacts
+
+go 1.16
+
+require (
+	github.com/oglinuk/cmdtab-links v1.3.0
+	github.com/rwxrob/cmdtab v0.5.0
+)

--- a/examples/iacts/go.sum
+++ b/examples/iacts/go.sum
@@ -1,0 +1,9 @@
+github.com/oglinuk/cmdtab-links v1.3.0 h1:tz7/Uyn7ZbGXII9HB59/LZBSXBTqUwX8/bx2MkEejNM=
+github.com/oglinuk/cmdtab-links v1.3.0/go.mod h1:zdv6gBjczNh0xXVDyNsngrhXgxGZ2UopeEWDMTIceFE=
+github.com/rwxrob/cmdtab v0.4.0/go.mod h1:TWGCTFAm9NlO9mR6aUB5dltAhcVK1FTiCzF7WLXwGgQ=
+github.com/rwxrob/cmdtab v0.5.0 h1:WrzKLQDyoXk+jIHUjIY2u59tBzcbYXAbqOeynXLnGiA=
+github.com/rwxrob/cmdtab v0.5.0/go.mod h1:TWGCTFAm9NlO9mR6aUB5dltAhcVK1FTiCzF7WLXwGgQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/examples/iacts/iact.go
+++ b/examples/iacts/iact.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/rwxrob/cmdtab"
+	_ "github.com/oglinuk/cmdtab-links" // Import the 3rd party subcommand
+)
+
+func init() {
+	// Add subcommand root command
+	x := cmdtab.New("iact", "links")
+	x.Version = `v1.0.0`
+	x.License = `MPL-v2.0`
+}

--- a/examples/iacts/main.go
+++ b/examples/iacts/main.go
@@ -1,0 +1,6 @@
+package main
+
+import "github.com/rwxrob/cmdtab"
+
+// The most important line, which executes the root command
+func main() { cmdtab.Execute("iact") }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/rwxrob/cmdtab
 
-go 1.15
+go 1.16


### PR DESCRIPTION
Ive ensured there are no references to `io/ioutil` and updated the
`go.mod` version of Go to `1.16`. Ive also added an examples directory
with two examples; a basic implementation of cmdtab, and an
implementation showing how to import a 3rd party cmdtab-based
subcommand. This will resolve https://github.com/rwxrob/cmdtab/issues/1.